### PR TITLE
Support for setuptools build/install of PyMuTT added

### DIFF
--- a/PyMuTT/__init__.py
+++ b/PyMuTT/__init__.py
@@ -3,6 +3,17 @@
 PyMuTT
 """
 
+####
+#
+# setuptools likes to see a name for the package,
+# and it's best-practices to have the __version__
+# present, too:
+#
+name = 'PyMuTT'
+__version__ = '0.1.0'
+#
+####
+
 import re
 import inspect
 from warnings import warn

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,47 @@
+#
+# setup.py
+#
+# Installation script to get setuptools to install PyMuTT into
+# a Python environment.
+#
+
+import sys
+import setuptools
+
+# Import the lengthy rich-text README as the package's long
+# description:
+with open('README.rst', 'r') as fh:
+	long_description = fh.read()
+
+setuptools_info = {
+	'name': 'PyMuTT',
+	'version': '1.0.0',
+	'author': 'Vlachos Research Group',
+	'author_email': 'vlachos@udel.edu',
+	'description': 'Python Multiscale Thermochemistry Toolbox (PyMuTT)',
+	'long_description': long_description,
+	'zip_safe': True,
+	'url': 'https://github.com/VlachosGroup/PyMuTT',
+	'install_requires': [
+		'ASE>=3.16.2',
+		'matplotlib>=2.2.3',
+		'numpy>=1.15.1',
+		'scipy>=1.1.0',
+		'pandas>=0.20.3',
+	    ],
+	'classifiers': [
+		"Programming Language :: Python :: 3",
+		"License :: OSI Approved :: MIT License",
+		"Operating System :: OS Independent",
+		"Intended Audience :: Science/Research",
+		"Topic :: Scientific/Engineering :: Chemistry",
+	    ],
+    }
+
+if sys.version_info[0] >= 3:
+	#
+	# Augment for Python 3 setuptools:
+	#
+	setuptools_info['long_description_content_type'] = 'text/x-rst'
+
+setuptools.setup(**setuptools_info)


### PR DESCRIPTION
Addition of two variables (`name`, `__version__`) to `PyMuTT/__init__.py` and creation of a `setup.py` script.  Running the following in this source directory:

```
$ python setup.py sdist
```

will produce `dist/PyMuTT-1.0.0.tar.gz` which can be distributed and installed with pip:

```
$ pip install PyMuTT-1.0.0.tar.gz
```

or manually by unpacking:

```
$ tar -zxf PyMuTT-1.0.0.tar.gz
$ cd PyMuTT-1.0.0
$ python setup.py install --prefix=/some/other/directory
```

For the manual method to succeed, the necessary versions of all the dependencies (numpy, scipy, matplotlib, ASE, and pandas) must have been installed already.  When using pip, the dependencies will be checked and installed automatically.

Various binary distribution formats can be produced, as well.  E.g.

```
$ python setup.py bdist_egg
```

or

```
$ python3 setup.py bdist_wheel
```

